### PR TITLE
Default to rbzip, but use bzip2-ruby if available.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'rspec'
 gem 'watchr'
 gem 'rr'
 gem 'rake'
+
+gem 'bzip2-ruby'

--- a/lib/tassadar.rb
+++ b/lib/tassadar.rb
@@ -6,10 +6,10 @@ require 'tassadar/bzip'
 
 begin
   require 'bzip2'
-  BZIP = Tassadar::BZip.set_implementation('bzip2')
+  Tassadar::BZip.set_implementation('bzip2')
 rescue LoadError, Tassadar::BZip::DefaultToRbzip
   require 'rbzip2'
-  BZIP = Tassadar::BZip.set_implementation('rbzip2')
+  Tassadar::BZip.set_implementation('rbzip2')
 end
 
 module Tassadar

--- a/lib/tassadar.rb
+++ b/lib/tassadar.rb
@@ -2,6 +2,15 @@ $:.unshift File.join(File.dirname(__FILE__), 'lib')
 
 require 'tassadar/mpq'
 require 'tassadar/sc2/replay'
+require 'tassadar/bzip'
+
+begin
+  require 'bzip2'
+  BZIP = Tassadar::BZip.set_implementation('bzip2')
+rescue LoadError, Tassadar::BZip::DefaultToRbzip
+  require 'rbzip2'
+  BZIP = Tassadar::BZip.set_implementation('rbzip2')
+end
 
 module Tassadar
 end

--- a/lib/tassadar/bzip.rb
+++ b/lib/tassadar/bzip.rb
@@ -1,0 +1,19 @@
+module Tassadar
+  class BZip
+    class DefaultToRbzip < Exception; end
+
+    def self.decompress(data)
+      case @@implementation
+      when 'bzip2'
+        Bzip2.uncompress(data)
+      when 'rbzip2'
+        RBzip2::Decompressor.new(StringIO.new(data)).read
+      end
+    end
+
+    def self.set_implementation(implementation)
+      raise DefaultToRbzip if ENV['RBZIP2'] && implementation != 'rbzip2'
+      @@implementation = implementation
+    end
+  end
+end

--- a/lib/tassadar/mpq/file_data.rb
+++ b/lib/tassadar/mpq/file_data.rb
@@ -2,14 +2,6 @@ require 'zlib'
 require 'stringio'
 require 'tassadar/bzip'
 
-begin
-  require 'bzip2'
-  BZIP = Tassadar::BZip.set_implementation('bzip2')
-rescue LoadError, Tassadar::BZip::DefaultToRbzip
-  require 'rbzip2'
-  BZIP = Tassadar::BZip.set_implementation('rbzip2')
-end
-
 module Tassadar
   module MPQ
     class FileData < BinData::Record

--- a/lib/tassadar/mpq/file_data.rb
+++ b/lib/tassadar/mpq/file_data.rb
@@ -1,6 +1,14 @@
 require 'zlib'
-require 'rbzip2'
 require 'stringio'
+require 'tassadar/bzip'
+
+begin
+  require 'bzip2'
+  BZIP = Tassadar::BZip.set_implementation('bzip2')
+rescue LoadError, Tassadar::BZip::DefaultToRbzip
+  require 'rbzip2'
+  BZIP = Tassadar::BZip.set_implementation('rbzip2')
+end
 
 module Tassadar
   module MPQ
@@ -47,7 +55,7 @@ module Tassadar
         when 2
           Zlib::Deflate.deflate(data[1,data.size - 1])
         when 16
-          RBzip2::Decompressor.new(StringIO.new(data[1,data.size - 1])).read
+          BZip.decompress(data[1,data.size - 1])
         else
           raise NotImplementedError
         end


### PR DESCRIPTION
See discussion in #6.

If bzip2-ruby is available, use it because it's faster.  Default to rbzip2 for compatibility.

tassadar [bzip2-ruby*] → time rake > /dev/null
rake > /dev/null  0.81s user 0.08s system 99% cpu 0.897 total

tassadar [bzip2-ruby*] → time RBZIP2=true rake > /dev/null
RBZIP2=true rake > /dev/null  1.34s user 0.08s system 99% cpu 1.436 total
