### PR TITLE
Update Spec Suite

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---color --format nested --order random
+--color --format documentation --order random

--- a/spec/tassadar/mpq/archive_header_spec.rb
+++ b/spec/tassadar/mpq/archive_header_spec.rb
@@ -1,64 +1,64 @@
 require 'spec_helper'
 
 describe Tassadar::MPQ::ArchiveHeader do
-  before(:each) do
-    @archive_header = Tassadar::MPQ::ArchiveHeader.read("MPQ\x1A,\x00\x00\x00P5\x00\x00\x01\x00\x03\x00\xB03\x00\x00\xB04\x00\x00\x10\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+  let(:archive_header) do
+    Tassadar::MPQ::ArchiveHeader.read("MPQ\x1A,\x00\x00\x00P5\x00\x00\x01\x00\x03\x00\xB03\x00\x00\xB04\x00\x00\x10\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
   end
 
   describe "require a valid magic string" do
-    it "should accept a valid magic string" do
+    it "accepts a valid magic string" do
       expect { Tassadar::MPQ::ArchiveHeader.read("MPQ\x1A,\x00\x00\x00P5\x00\x00\x01\x00\x03\x00\xB03\x00\x00\xB04\x00\x00\x10\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00") }.to_not raise_error
     end
 
-    it "should not accept an invalid magic string" do
-      expect { Tassadar::MPQ.ArchiveHeader.read("MPQ\x1A,\x00\x00\x00P5\x00\x00\x01\x00\x03\x00\xB03\x00\x00\xB04\x00\x00\x10\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00") }.to raise_error
+    it "does not accept an invalid magic string" do
+      expect { Tassadar::MPQ.ArchiveHeader.read("MPQ\x1A,\x00\x00\x00P5\x00\x00\x01\x00\x03\x00\xB03\x00\x00\xB04\x00\x00\x10\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00") }.to raise_error(/undefined method/)
     end
   end
 
-  it "should read the header size" do
-    @archive_header.header_size.should == 44
+  it "reads the header size" do
+    expect(archive_header.header_size).to eq(44)
   end
 
-  it "should read the archive size" do
-    @archive_header.archive_size.should == 13648
+  it "reads the archive size" do
+    expect(archive_header.archive_size).to eq(13648)
   end
 
-  it "should read the format version" do
-    @archive_header.format_version.should == 1
+  it "reads the format version" do
+    expect(archive_header.format_version).to eq(1)
   end
 
-  it "should read the sector size shift" do
-    @archive_header.sector_size_shift.should == 3
+  it "reads the sector size shift" do
+    expect(archive_header.sector_size_shift).to eq(3)
   end
 
-  it "should read the hash table offset" do
-    @archive_header.hash_table_offset.should == 13232
+  it "reads the hash table offset" do
+    expect(archive_header.hash_table_offset).to eq(13232)
   end
 
-  it "should read the block table offset" do
-    @archive_header.block_table_offset.should == 13488
+  it "reads the block table offset" do
+    expect(archive_header.block_table_offset).to eq(13488)
   end
 
-  it "should read the hash table entries" do
-    @archive_header.hash_table_entries.value.should > 0
-    @archive_header.hash_table_entries.value.should < 2 ** 20
-    Math.log2(@archive_header.hash_table_entries.to_i).floor.should == Math.log2(@archive_header.hash_table_entries.to_i).ceil
-    @archive_header.hash_table_entries.should == 16
+  it "reads the hash table entries" do
+    expect(archive_header.hash_table_entries.value).to be > 0
+    expect(archive_header.hash_table_entries.value).to be < 2 ** 20
+    expect(Math.log2(archive_header.hash_table_entries.to_i).floor).to eq(Math.log2(archive_header.hash_table_entries.to_i).ceil)
+    expect(archive_header.hash_table_entries).to eq(16)
   end
 
-  it "should read the block table entries" do
-    @archive_header.block_table_entries.should == 10
+  it "reads the block table entries" do
+    expect(archive_header.block_table_entries).to eq(10)
   end
 
-  it "should read the extended_block_table_offset" do
-    @archive_header.extended_block_table_offset.should == 0
+  it "reads the extended_block_table_offset" do
+    expect(archive_header.extended_block_table_offset).to eq(0)
   end
 
-  it "should read the hash table offset high" do
-    @archive_header.hash_table_offset_high.should == 0
+  it "reads the hash table offset high" do
+    expect(archive_header.hash_table_offset_high).to eq(0)
   end
 
-  it "should read the block table offset high" do
-    @archive_header.block_table_offset_high.should == 0
+  it "reads the block table offset high" do
+    expect(archive_header.block_table_offset_high).to eq(0)
   end
 end

--- a/spec/tassadar/mpq/block_table_spec.rb
+++ b/spec/tassadar/mpq/block_table_spec.rb
@@ -1,28 +1,26 @@
 require 'spec_helper'
 
 describe Tassadar::MPQ::ArchiveHeader do
-  before(:each) do
-    @mpq = Tassadar::MPQ::MPQ.read(File.read(File.join(REPLAY_DIR, "Delta\ Quadrant.SC2Replay")))
+  let(:mpq) { Tassadar::MPQ::MPQ.read(File.read(File.join(REPLAY_DIR, "Delta\ Quadrant.SC2Replay"))) }
+
+  it "has 10 blocks" do
+    expect(mpq.block_table.blocks.size).to eq(10)
   end
 
-  it "should have some blocks" do
-    @mpq.block_table.blocks.size.should == 10
+  it "has a valid block table entry" do
+    block = mpq.block_table.blocks.first
+    expect(block.block_offset).to eq(0x0000002C)
+    expect(block.block_size).to eq(448)
+    expect(block.file_size).to eq(448)
+    expect(block.flags).to eq(0x81000200)
   end
 
-  it "should have a valid block table entry" do
-    block = @mpq.block_table.blocks.first
-    block.block_offset.should == 0x0000002C
-    block.block_size.should == 448
-    block.file_size.should == 448
-    block.flags.should == 0x81000200
-  end
-  
-  it "should have another valid block table entry" do
-    block = @mpq.block_table.blocks[1]
-    block.block_offset.should == 0x000001EC
-    block.block_size.should == 652
-    block.file_size.should == 1216
-    block.flags.should == 0x81000200
+  it "has another valid block table entry" do
+    block = mpq.block_table.blocks[1]
+    expect(block.block_offset).to eq(0x000001EC)
+    expect(block.block_size).to eq(652)
+    expect(block.file_size).to eq(1216)
+    expect(block.flags).to eq(0x81000200)
   end
 end
 

--- a/spec/tassadar/mpq_spec.rb
+++ b/spec/tassadar/mpq_spec.rb
@@ -1,28 +1,26 @@
 require 'spec_helper'
 
 describe Tassadar::MPQ::MPQ do
-  before(:each) do
-    @mpq = Tassadar::MPQ::MPQ.read(File.read(File.join(REPLAY_DIR, 'patch150.SC2Replay')))
+  let(:mpq) { Tassadar::MPQ::MPQ.read(File.read(File.join(REPLAY_DIR, 'patch150.SC2Replay'))) }
+
+  it "reads the user data size" do
+    expect(mpq.user_data_length).to eq(60)
   end
 
-  it "should read the user data size" do
-    @mpq.user_data_length.should == 60
+  it "has block_table entries" do
+    expect(mpq.block_table.blocks.size).to eq(10)
   end
 
-  it "should have block_table entries" do
-    @mpq.block_table.blocks.size.should == 10
+  it "has hash_table entries" do
+    expect(mpq.hash_table.hashes.size).to eq(16)
   end
 
-  it "should have hash_table entries" do
-    @mpq.hash_table.hashes.size.should == 16
+  it "has files" do
+    expect(mpq.file_data.size).to be > 1
   end
 
-  it "should have files" do
-    @mpq.file_data.size.should > 1
-  end
-
-  it "should have a list of files" do
-    @mpq.files.size.should == 8
-    @mpq.files.should include("replay.attributes.events")
+  it "has a list of files" do
+    expect(mpq.files.size).to eq(8)
+    expect(mpq.files).to include("replay.attributes.events")
   end
 end

--- a/spec/tassadar/sc2/game_spec.rb
+++ b/spec/tassadar/sc2/game_spec.rb
@@ -1,44 +1,42 @@
 require 'spec_helper'
 
 describe Tassadar::SC2::Game do
-  before(:each) do
-    @replay = Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "patch150.SC2Replay"))
+  let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "patch150.SC2Replay")) }
+
+  it "sets the winner" do
+    expect(replay.game.winner.name).to eq("Ratbaxter")
   end
 
-  it "should set the winner" do
-    @replay.game.winner.name.should == "Ratbaxter"
+  it "sets the map" do
+    expect(replay.game.map).to eq("Scorched Haven")
   end
 
-  it "should set the map" do
-    @replay.game.map.should == "Scorched Haven"
+  it "sets the time" do
+    #expect(replay.game.time).to eq(Time.new(2012, 8, 2, 11, 00, 33, "-05:00"))
   end
 
-  it "should set the time" do
-    #@replay.game.time.should == Time.new(2012, 8, 2, 11, 00, 33, "-05:00")
+  it "sets the speed" do
+    expect(replay.game.speed).to eq("Faster")
   end
 
-  it "should set the speed" do
-    @replay.game.speed.should == "Faster"
+  it "sets the game type" do
+    expect(replay.game.type).to eq("2v2")
   end
 
-  it "should set the game type" do
-    @replay.game.type.should == "2v2"
-  end
-
-  it "should set the category" do
-    @replay.game.category.should == "Ladder"
+  it "sets the category" do
+    expect(replay.game.category).to eq("Ladder")
   end
 
   context "2v2's" do
     let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "2v2.SC2Replay")) }
 
     it "returns the game winners" do
-      expect(replay.game).to have(2).winners
+      expect(replay.game.winners.length).to eq(2)
     end
 
     it "returns the correct winners" do
       winners = replay.game.winners.map(&:name)
-      expect(winners).to eq ["EaglePunch", "JZTD"]
+      expect(winners).to match_array(["EaglePunch", "JZTD"])
     end
   end
 end

--- a/spec/tassadar/sc2/player_spec.rb
+++ b/spec/tassadar/sc2/player_spec.rb
@@ -7,36 +7,36 @@ describe Tassadar::SC2::Player do
   context 'NA SC2 Replay' do
     let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "OhanaLE.SC2Replay")) }
 
-    it "should set the name" do
-      player.name.should == "MLGLogan"
+    it "sets the name" do
+      expect(player.name).to eq("MLGLogan")
     end
 
-    it "should set the id" do
-      player.id.should == 1485031
+    it "sets the id" do
+      expect(player.id).to eq(1485031)
     end
 
-    it "should tell if the player won" do
-      player.should_not be_winner
+    it "tells if the player won" do
+      expect(player).to_not be_winner
     end
 
-    it "should have a color" do
-      player.color.should == {:alpha => 255, :red => 0, :green => 66, :blue => 255}
+    it "has a color" do
+      expect(player.color).to eq({:alpha => 255, :red => 0, :green => 66, :blue => 255})
     end
 
-    it "should have random as the chosen race if random" do
-      player.chosen_race.should == "Random"
+    it "has random as the chosen race if random" do
+      expect(player.chosen_race).to eq("Random")
     end
 
-    it "should have an actual race" do
-      player.actual_race.should == "Protoss"
+    it "has an actual race" do
+      expect(player.actual_race).to eq("Protoss")
     end
 
-    it "should have a handicap" do
-      player.handicap.should == 100
+    it "has a handicap" do
+      expect(player.handicap).to eq(100)
     end
 
-    it "should set the team" do
-      player.team.should == 0
+    it "sets the team" do
+      expect(player.team).to eq(0)
     end
   end
 
@@ -44,13 +44,14 @@ describe Tassadar::SC2::Player do
     let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, 'eu_replay.SC2Replay')) }
 
     it 'encodes the name in UTF-8' do
-      player.name.encoding.to_s.should == 'UTF-8'
-      player.name.should == 'MǂStephano'
+      expect(player.name.encoding.to_s).to eq('UTF-8')
+      expect(player.name).to eq('MǂStephano')
     end
   end
 
   context "replay with a player who has a clan tag" do
     let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, 'game_with_clan_tag.SC2Replay')) }
+
     subject(:player) { replay.players.first }
 
     it "returns the name without a <sp/>" do

--- a/spec/tassadar/sc2/replay_spec.rb
+++ b/spec/tassadar/sc2/replay_spec.rb
@@ -1,28 +1,25 @@
 require 'spec_helper'
 
 describe Tassadar::SC2::Game do
-  before(:each) do
-    @replay = Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "patch150.SC2Replay"))
-    @replay_from_data = Tassadar::SC2::Replay.new(nil, File.read(File.join(REPLAY_DIR, "patch150.SC2Replay")))
+  let(:replay) { Tassadar::SC2::Replay.new(File.join(REPLAY_DIR, "patch150.SC2Replay")) }
+  let(:replay_from_data) { Tassadar::SC2::Replay.new(nil, File.read(File.join(REPLAY_DIR, "patch150.SC2Replay"))) }
+
+  it "has the same result" do
+    expect(replay.game.winner.name).to eq(replay_from_data.game.winner.name)
   end
 
-  it "should have the same result" do
-    @replay.game.winner.name.should == @replay_from_data.game.winner.name
+  it "has players" do
+    expect(replay.players).to_not be_nil
+    expect(replay_from_data.players).to_not be_nil
   end
 
-  it "should have players" do
-    @replay.players.should be_true
-    @replay_from_data.players.should be_true
-  end
-  
-  it "should have game" do
-    @replay.game.should be_true
-    @replay_from_data.game.should be_true
-  end
-  
-  it "should have details" do
-    @replay.details.should be_true
-    @replay_from_data.details.should be_true
+  it "has game" do
+    expect(replay.game).to_not be_nil
+    expect(replay_from_data.game).to_not be_nil
   end
 
+  it "has details" do
+    expect(replay.details).to_not be_nil
+    expect(replay_from_data.details).to_not be_nil
+  end
 end

--- a/spec/tassadar/version_spec.rb
+++ b/spec/tassadar/version_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Tassadar::VERSION' do
-  it 'should be the correct version' do
-    Tassadar::VERSION.should == '0.3.0'
+  it 'is the correct version' do
+    expect(Tassadar::VERSION).to eq('0.3.0')
   end
 end


### PR DESCRIPTION
@czarneckid 

Even though the development dependency of this is not yet rspec 3, these changes will make the transition much easier when neeeded :)

Summary of Changes:
1. Following the [better specs](http://betterspecs.org/) guidelines, I changed the assertion text in specs to remove the word "should". This allows the specs to describe in more natural language what they expect to happen.
2. I added an explicit assertion for the lack of an error. This will better communicate that an error was raised when not expected instead of simply that an error was raised. 
3. Instance variables were removed in favour of `let` assignments.
4. The `should` matcher has been replaced by the `expect` matcher.
5. In `.rspec`, I have removed an old formatter option `nested` which has not been present since rspec 1

This spec suite is now void of deprecation warnings and since the `.gemspec` is not locked to a specific rspec version, new developers will be able to run the suite without issue with the latest rspec version.
